### PR TITLE
Fix missing braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,15 @@ Makefile
 stamp-*
 libtool
 
+src/bin
+autom4te.cache/
+src/extensions/far/farcompilestrings
+src/extensions/far/farcreate
+src/extensions/far/farequal
+src/extensions/far/farextract
+src/extensions/far/farinfo
+src/extensions/far/farprintstrings
+
 # Xcode
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore

--- a/src/include/fst/arc-map.h
+++ b/src/include/fst/arc-map.h
@@ -172,10 +172,11 @@ void ArcMap(MutableFst<A> *fst, C* mapper) {
         if (s != superfinal) {
           A final_arc = (*mapper)(A(0, 0, fst->Final(s), kNoStateId));
           if (final_arc.ilabel != 0 || final_arc.olabel != 0 ||
-              final_arc.weight != Weight::Zero())
+              final_arc.weight != Weight::Zero()) {
             fst->AddArc(s, A(final_arc.ilabel, final_arc.olabel,
                              final_arc.weight, superfinal));
-            fst->SetFinal(s, Weight::Zero());
+          }
+          fst->SetFinal(s, Weight::Zero());
         }
         break;
       }


### PR DESCRIPTION
GCC > 6.0 complains about misleading indentations like the one
addressed here.  From the surrounding code, it looks like the intention
is to have the FinalWeight set only in the body of the if.

Signed-off-by: Eric B Munson <emunson@mgebm.net>